### PR TITLE
Update health-agent.service

### DIFF
--- a/init.d/health-agent.service
+++ b/init.d/health-agent.service
@@ -1,14 +1,14 @@
 [Unit]
 Description=System health agent
 After=network.target
+StartLimitIntervalSec=1000
+StartLimitBurst=1000
 
 [Service]
 ExecStart=/usr/local/sbin/health-agent
 Nice=1
 Restart=always
 RestartSec=1
-StartLimitIntervalSec=1000
-StartLimitBurst=1000
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Moved below params from Service section to Unit section  for health-agent service 
StartLimitIntervalSec=1000
StartLimitBurst=1000

This is done to fix 
Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring