### PR TITLE
Extends the testprog prober to support executing commands with arguments.

### DIFF
--- a/cmd/health-agent/healthcheck.go
+++ b/cmd/health-agent/healthcheck.go
@@ -29,13 +29,14 @@ type testConfig struct {
 }
 
 type testSpecs struct {
-	Address    string `yaml:"address"`
-	Hostname   string `yaml:"hostname"`
-	Network    string `yaml:"network"`
-	Pathname   string
-	SssdConfig string `yaml:"sssd-config"`
-	Urlpath    string `yaml:"url-path"`
-	Urlport    uint   `yaml:"url-port"`
+	Address    string   `yaml:"address"`
+	Hostname   string   `yaml:"hostname"`
+	Network    string   `yaml:"network"`
+	Pathname   string   `yaml:"pathname"`
+	Args       []string `yaml:"args"`
+	SssdConfig string   `yaml:"sssd-config"`
+	Urlpath    string   `yaml:"url-path"`
+	Urlport    uint     `yaml:"url-port"`
 }
 
 func setupHealthchecks(configDir string, pl *proberlist.ProberList,
@@ -136,7 +137,7 @@ func makeProber(testname string, c *testConfig,
 		if testprogpath == "" {
 			return nil
 		}
-		return testprogprober.Maketestprogprober(testname, testprogpath)
+		return testprogprober.Maketestprogprober(testname, testprogpath, c.Specs.Args...)
 	case "url":
 		urlpath := c.Specs.Urlpath
 		urlport := c.Specs.Urlport

--- a/probers/testprog/api.go
+++ b/probers/testprog/api.go
@@ -6,7 +6,8 @@ import (
 
 type testprogconfig struct {
 	testname  string
-	filepath  string
+	command   string
+	args      []string
 	healthy   bool
 	exitCode  int
 	exitError string
@@ -14,10 +15,11 @@ type testprogconfig struct {
 	stderr    string
 }
 
-func Maketestprogprober(testname string, testprogpath string) *testprogconfig {
+func Maketestprogprober(testname string, command string, args ...string) *testprogconfig {
 	p := new(testprogconfig)
 	p.testname = testname
-	p.filepath = testprogpath
+	p.command = command
+	p.args = args
 	return p
 }
 

--- a/probers/testprog/probe.go
+++ b/probers/testprog/probe.go
@@ -9,11 +9,14 @@ import (
 )
 
 func (p *testprogconfig) probe() error {
-	if _, err := os.Stat(p.filepath); os.IsNotExist(err) {
-		p.sethealthy(false, err)
-		return err
+	// Check if command exists as file or in PATH
+	if _, err := os.Stat(p.command); os.IsNotExist(err) {
+		if _, err := exec.LookPath(p.command); err != nil {
+			p.sethealthy(false, err)
+			return err
+		}
 	}
-	cmd := exec.Command(p.filepath)
+	cmd := exec.Command(p.command, p.args...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		p.sethealthy(false, err)


### PR DESCRIPTION
Extends the testprog prober to support executing commands with arguments.

Changes:
- Added `args` field to testprog config
- Updated `Maketestprogprober` to accept variadic args
- Added PATH lookup for commands not specified as absolute paths

Example config:
```yaml
type: testprog
probe-freq: 1
specs:
  pathname: systemctl
  args:
    - is-active
    - --quiet
    - systemd-networkd